### PR TITLE
Handle 200-with-empty-body responses in shared HTTP client

### DIFF
--- a/src/shared/client.ts
+++ b/src/shared/client.ts
@@ -532,7 +532,23 @@ export function createClient(config: ClientConfig): ApiClient {
       throw new Error(`${name}: HTTP ${res.status} — ${body || res.statusText}`);
     }
 
-    const data = await res.json();
+    // Some upstream endpoints (e.g. DOL OSHA "no results") return 200 with an
+    // empty body. Read as text first so we can short-circuit instead of letting
+    // res.json() throw "Unexpected end of JSON input".
+    const raw = await res.text();
+    let data: unknown;
+    if (raw.trim() === "") {
+      data = null;
+    } else {
+      try {
+        data = JSON.parse(raw);
+      } catch (err) {
+        const preview = raw.length > 200 ? `${raw.slice(0, 200)}…` : raw;
+        throw new Error(
+          `${name}: invalid JSON response (HTTP ${res.status}): ${(err as Error).message}. Body: ${preview}`,
+        );
+      }
+    }
 
     // Check for API-level errors in body
     if (checkError) {

--- a/tests/client-empty-body.test.ts
+++ b/tests/client-empty-body.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests for the shared HTTP client's empty-body handling.
+ *
+ * Some upstream APIs (e.g. DOL OSHA "no results") return HTTP 200 with an
+ * empty body. Before the fix, `await res.json()` threw
+ * "Unexpected end of JSON input" and bubbled out of the tool execute() —
+ * see https://github.com/lzinga/us-gov-open-data-mcp/issues for context.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createClient } from "../src/shared/client.js";
+
+describe("createClient — empty/invalid body handling", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    // Keep cache effects out of these tests by varying the URL per case.
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("returns null when the upstream returns 200 with an empty body", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response("", { status: 200, headers: { "content-type": "application/json" } }),
+    ) as typeof fetch;
+
+    const client = createClient({
+      baseUrl: "https://example.test",
+      name: "empty-body-test",
+    });
+
+    const data = await client.get<unknown>("/empty");
+    expect(data).toBeNull();
+  });
+
+  it("returns null when the upstream returns 200 with a whitespace-only body", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response("   \n\t", { status: 200, headers: { "content-type": "application/json" } }),
+    ) as typeof fetch;
+
+    const client = createClient({
+      baseUrl: "https://example.test",
+      name: "whitespace-body-test",
+    });
+
+    const data = await client.get<unknown>("/whitespace");
+    expect(data).toBeNull();
+  });
+
+  it("throws a helpful error when the upstream returns 200 with non-JSON body", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response("<html>oops</html>", { status: 200, headers: { "content-type": "text/html" } }),
+    ) as typeof fetch;
+
+    const client = createClient({
+      baseUrl: "https://example.test",
+      name: "html-body-test",
+    });
+
+    await expect(client.get<unknown>("/html")).rejects.toThrow(
+      /html-body-test: invalid JSON response.*<html>oops<\/html>/,
+    );
+  });
+
+  it("returns parsed JSON when the upstream returns valid JSON", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ ok: true, count: 3 }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    ) as typeof fetch;
+
+    const client = createClient({
+      baseUrl: "https://example.test",
+      name: "valid-json-test",
+    });
+
+    const data = await client.get<{ ok: boolean; count: number }>("/data");
+    expect(data).toEqual({ ok: true, count: 3 });
+  });
+});


### PR DESCRIPTION
## Description

Some upstream APIs return HTTP 200 with an empty body when there are no rows matching the filter. The shared HTTP client called `await res.json()` directly, which throws `SyntaxError: Unexpected end of JSON input`. That bubbles out of `tool.execute()` as a confusing error instead of an empty result.

Reproduced via `dol_osha_accidents` with `event_keyword: "keyword"`:

```
{"content":"Tool 'dol_osha_accidents' execution failed: Unexpected end of JSON input"}
```

The companion tool `dol_osha_inspections` handles "no results" cleanly (returns the standard `emptyResponse`), so the inconsistency is purely in the client's body-parsing path.

This change reads the body as text first in `src/shared/client.ts`:
- If the body is empty or whitespace-only, returns `null` (the existing `Array.isArray(data) || !data.length` checks in tool wrappers already handle this and emit `emptyResponse`).
- If the body is non-empty but not valid JSON, throws a clearer error that includes the request name, status code, and a 200-char body preview — much friendlier to debug than a bare `Unexpected end of JSON input`.
- Valid JSON still flows through unchanged.

Adds vitest coverage for all four cases (empty, whitespace, non-JSON, valid JSON).

## Type of Change

- [x] Bug fix

## Verification

- `npm run build` — passes
- `npm test` — 926/926 passed (922 existing + 4 new)

## Additional Notes

The fix is in shared client code, so it benefits every module that uses `createClient` (FRED, DOL, BLS, etc.) — not just DOL. If any other API silently returns empty bodies, those will now degrade to `emptyResponse` instead of throwing.

I considered making the JSON-parse error a soft warning + `null` rather than a throw, but the current behavior (rejecting non-JSON 200s as errors) is probably what most callers want, and changing that would be a behavior change beyond the scope of this fix.
